### PR TITLE
Add better errors

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -21,11 +21,22 @@ impl Error {
         Self::TokenizeError(format!("failed to tokenize {}: {}", tuple.0, tuple.1))
     }
 
-    pub fn parser<T>(element: &'static str, part: T) -> Self
+    pub fn parser<I>(element: &'static str, input: I) -> Self
     where
-        T: std::fmt::Display,
+        I: std::fmt::Display,
     {
-        Self::TokenizeError(format!("failed to parse {}: {}", element, part))
+        Self::ParseError(format!("failed to parse {}: {}", element, input))
+    }
+
+    pub fn parser_with_error<I, E>(element: &'static str, input: I, error: E) -> Self
+    where
+        I: std::fmt::Display,
+        E: std::fmt::Display,
+    {
+        Self::ParseError(format!(
+            "failed to parse {} ( {} ): {}",
+            element, error, input
+        ))
     }
 }
 
@@ -48,8 +59,8 @@ impl From<nom::Err<TokenizerError>> for Error {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            Self::TokenizeError(inner) => write!(f, "Tokenizer error: {}", inner),
-            Self::ParseError(inner) => write!(f, "sdp error: could not parse part: {}", inner),
+            Self::TokenizeError(inner) => write!(f, "tokenizer error: {}", inner),
+            Self::ParseError(inner) => write!(f, "could not parse part: {}", inner),
             Self::Incomplete => write!(f, "sdp error: incomplete input"),
         }
     }

--- a/src/media_description.rs
+++ b/src/media_description.rs
@@ -34,8 +34,8 @@ impl<'a> TryFrom<Tokenizer<'a>> for MediaDescription {
             attributes: tokenizer
                 .attributes
                 .into_iter()
-                .map(Into::into)
-                .collect::<Vec<_>>(),
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
         })
     }
 }

--- a/src/session_description.rs
+++ b/src/session_description.rs
@@ -83,8 +83,8 @@ impl<'a> TryFrom<Tokenizer<'a>> for SessionDescription {
             attributes: tokenizer
                 .attributes
                 .into_iter()
-                .map(Into::into)
-                .collect::<Vec<_>>(),
+                .map(TryInto::try_into)
+                .collect::<Result<Vec<_>, _>>()?,
             media_descriptions: tokenizer
                 .media_descriptions
                 .into_iter()
@@ -548,5 +548,37 @@ mod tests {
 
         let parsed_sdp = SessionDescription::try_from(Tokenizer::tokenize(sdp).unwrap().1).unwrap();
         assert_eq!(parsed_sdp.to_string(), sdp);
+    }
+
+    #[test]
+    fn errors1() {
+        let sdp = concat!(
+            "v=0\r\n",
+            "o=Alice 2890844526 2890842807 IN IP4 10.47.16.5\r\n",
+            "s=-\r\n",
+            "i=A Seminar on the session description protocol\r\n",
+            "u=http://www.example.com/seminars/sdp.pdf\r\n",
+            "e=alice@example.com (Alice Smith)\r\n",
+            "p=+1 911-345-1160\r\n",
+            "c=IN IP4 10.47.16\r\n",
+            "b=CT:1024\r\n",
+            "t=2854678930 2854679000\r\n",
+            "r=604800 3600 0 90000\r\n",
+            "z=2882844526 -1h 2898848070 0h\r\n",
+            "k=clear:password\r\n",
+            "a=recvonly\r\n",
+            "m=audio 49170 RTP/AVP 0\r\n",
+            "i=audio media\r\n",
+            "c=IN IP4 10.47.16.5\r\n",
+            "c=IN IP4 10.47.16.6\r\n",
+            "b=CT:1000\r\n",
+            "b=AS:551\r\n",
+            "k=prompt\r\n",
+            "a=rtpmap:99 h232-199/90000\r\n",
+            "a=rtpmap:99 h263-1998/90000\r\n"
+        );
+
+        let parsed_sdp = SessionDescription::try_from(sdp);
+        assert!(parsed_sdp.is_err());
     }
 }

--- a/src/tokenizers/attributes/name_optvalue.rs
+++ b/src/tokenizers/attributes/name_optvalue.rs
@@ -12,9 +12,10 @@ impl<'a> Tokenizer<'a> {
         use nom::{branch::alt, combinator::rest};
 
         if part.is_empty() {
-            return Err(nom::Err::Error(TokenizerError::from(
-                "nothing more to tokenize",
-            )));
+            return Err(nom::Err::Error(TokenizerError {
+                context: "break; nothing more to tokenize".into(),
+                nom_kind: None,
+            }));
         }
 
         let (rem, name_with_value) = alt((until_stopbreak_of(";"), rest))(part)?;

--- a/src/tokenizers/connection/mod.rs
+++ b/src/tokenizers/connection/mod.rs
@@ -14,10 +14,10 @@ impl<'a> Tokenizer<'a> {
         use crate::parser_utils::*;
         use nom::{bytes::complete::tag, sequence::preceded};
 
-        let (rem, nettype) = preceded(tag("c="), until_space)(part)?;
-        let (rem, addrtype) = until_space(rem)?;
-        let (rem, connection_address) = until_newline(rem)?;
-        let (_, connection_address) = connection_address::Tokenizer::tokenize(connection_address)?;
+        let (rem, values) = preceded(tag("c="), until_newline)(part)?;
+        let (rem_line, nettype) = until_space(values)?;
+        let (rem_line, addrtype) = until_space(rem_line)?;
+        let (_, connection_address) = connection_address::Tokenizer::tokenize(rem_line)?;
 
         Ok((
             rem,

--- a/src/tokenizers/key_value.rs
+++ b/src/tokenizers/key_value.rs
@@ -11,8 +11,8 @@ impl<'a, const C: char> Tokenizer<'a, C> {
         use crate::parser_utils::*;
         use nom::{bytes::complete::tag, sequence::preceded};
 
-        let (rem, key) = preceded(tag(Self::prefix().as_str()), until_stopbreak_of(":"))(part)?;
-        let (rem, value) = until_newline(rem)?;
+        let (rem, key_with_value) = preceded(tag(Self::prefix().as_str()), until_newline)(part)?;
+        let (value, key) = until_stopbreak_of(":")(key_with_value)?;
 
         Ok((rem, (key, value).into()))
     }

--- a/src/tokenizers/media.rs
+++ b/src/tokenizers/media.rs
@@ -13,10 +13,10 @@ impl<'a> Tokenizer<'a> {
         use crate::parser_utils::*;
         use nom::{bytes::complete::tag, sequence::preceded};
 
-        let (rem, media) = preceded(tag("m="), until_space)(part)?;
-        let (rem, port_with_num_of_ports) = until_space(rem)?;
-        let (rem, proto) = until_space(rem)?;
-        let (rem, fmt) = until_newline(rem)?;
+        let (rem, line) = preceded(tag("m="), until_newline)(part)?;
+        let (line_rem, media) = until_space(line)?;
+        let (line_rem, port_with_num_of_ports) = until_space(line_rem)?;
+        let (fmt, proto) = until_space(line_rem)?;
         let (_, port) = PortTokenizer::tokenize(port_with_num_of_ports)?;
 
         Ok((

--- a/src/tokenizers/media_description.rs
+++ b/src/tokenizers/media_description.rs
@@ -24,7 +24,10 @@ impl<'a> Tokenizer<'a> {
             }
             false => (rem, None),
         };
+
+        //TODO: add loop for
         let (rem, connections) = match rem.starts_with("c=") {
+            //TODO: convert many1 to for loops
             true => many1(connection::Tokenizer::tokenize)(rem)?,
             false => (rem, vec![]),
         };

--- a/src/tokenizers/origin.rs
+++ b/src/tokenizers/origin.rs
@@ -15,12 +15,13 @@ impl<'a> Tokenizer<'a> {
         use crate::parser_utils::*;
         use nom::{bytes::complete::tag, sequence::preceded};
 
-        let (rem, username) = preceded(tag("o="), until_space)(part)?;
-        let (rem, sess_id) = until_space(rem)?;
-        let (rem, sess_version) = until_space(rem)?;
-        let (rem, nettype) = until_space(rem)?;
-        let (rem, addrtype) = until_space(rem)?;
-        let (rem, unicast_address) = until_newline(rem)?;
+        let (rem, line) = preceded(tag("o="), until_newline)(part)?;
+
+        let (line_rem, username) = until_space(line)?;
+        let (line_rem, sess_id) = until_space(line_rem)?;
+        let (line_rem, sess_version) = until_space(line_rem)?;
+        let (line_rem, nettype) = until_space(line_rem)?;
+        let (unicast_address, addrtype) = until_space(line_rem)?;
 
         Ok((
             rem,

--- a/src/tokenizers/time/active.rs
+++ b/src/tokenizers/time/active.rs
@@ -11,8 +11,8 @@ impl<'a> Tokenizer<'a> {
         use crate::parser_utils::*;
         use nom::{bytes::complete::tag, sequence::preceded};
 
-        let (rem, start) = preceded(tag("t="), until_space)(part)?;
-        let (rem, stop) = until_newline(rem)?;
+        let (rem, line) = preceded(tag("t="), until_newline)(part)?;
+        let (stop, start) = until_space(line)?;
 
         Ok((rem, (start, stop).into()))
     }

--- a/src/tokenizers/time/repeat.rs
+++ b/src/tokenizers/time/repeat.rs
@@ -12,9 +12,9 @@ impl<'a> Tokenizer<'a> {
         use crate::parser_utils::*;
         use nom::{bytes::complete::tag, multi::many0, sequence::preceded};
 
-        let (rem, interval) = preceded(tag("r="), until_space)(part)?;
-        let (rem, duration) = until_space(rem)?;
-        let (rem, offsets) = until_newline(rem)?;
+        let (rem, line) = preceded(tag("r="), until_newline)(part)?;
+        let (line_rem, interval) = until_space(line)?;
+        let (offsets, duration) = until_space(line_rem)?;
         let (offset, mut offsets) = many0(until_space)(offsets)?;
 
         offsets.push(offset);

--- a/src/tokenizers/time/zone.rs
+++ b/src/tokenizers/time/zone.rs
@@ -9,10 +9,9 @@ pub struct Tokenizer<'a> {
 impl<'a> Tokenizer<'a> {
     pub fn tokenize(part: &'a str) -> TResult<'a, Self> {
         use crate::parser_utils::*;
-        use nom::{bytes::complete::tag, multi::many1};
+        use nom::{bytes::complete::tag, multi::many1, sequence::preceded};
 
-        let (rem, _) = tag("z=")(part)?;
-        let (rem, line) = until_newline(rem)?;
+        let (rem, line) = preceded(tag("z="), until_newline)(part)?;
         let (_, parts) = many1(zone_part::Tokenizer::tokenize)(line)?;
 
         Ok((rem, Self { parts }))

--- a/src/types/bandwidth.rs
+++ b/src/types/bandwidth.rs
@@ -15,7 +15,9 @@ impl<'a> TryFrom<Tokenizer<'a, 'b'>> for Bandwidth {
     fn try_from(tokenizer: Tokenizer<'a, 'b'>) -> Result<Self, Self::Error> {
         Ok(Self {
             bwtype: tokenizer.key.into(),
-            bandwidth: tokenizer.value.parse()?,
+            bandwidth: tokenizer.value.parse().map_err(|e| {
+                Self::Error::parser_with_error("bandwidth value", tokenizer.value, e)
+            })?,
         })
     }
 }

--- a/src/types/connection/connection_address.rs
+++ b/src/types/connection/connection_address.rs
@@ -13,9 +13,25 @@ impl<'a> TryFrom<Tokenizer<'a>> for ConnectionAddress {
 
     fn try_from(tokenizer: Tokenizer<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
-            base: tokenizer.base.parse()?,
-            ttl: tokenizer.ttl.map(|ttl| ttl.parse()).transpose()?,
-            numaddr: tokenizer.numaddr.map(|ttl| ttl.parse()).transpose()?,
+            base: tokenizer.base.parse().map_err(|e| {
+                Self::Error::parser_with_error("connection address base", tokenizer.base, e)
+            })?,
+            ttl: tokenizer
+                .ttl
+                .map(|ttl| {
+                    ttl.parse().map_err(|e| {
+                        Self::Error::parser_with_error("connection address ttl", ttl, e)
+                    })
+                })
+                .transpose()?,
+            numaddr: tokenizer
+                .numaddr
+                .map(|numaddr| {
+                    numaddr.parse().map_err(|e| {
+                        Self::Error::parser_with_error("connection number of addresses", numaddr, e)
+                    })
+                })
+                .transpose()?,
         })
     }
 }

--- a/src/types/media/mod.rs
+++ b/src/types/media/mod.rs
@@ -23,11 +23,16 @@ impl<'a> TryFrom<Tokenizer<'a>> for Media {
     fn try_from(tokenizer: Tokenizer<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
             media: tokenizer.media.into(),
-            port: tokenizer.port.port.parse()?,
+            port: tokenizer.port.port.parse().map_err(|e| {
+                Self::Error::parser_with_error("media port", tokenizer.port.port, e)
+            })?,
             num_of_ports: tokenizer
                 .port
                 .num_of_ports
-                .map(|num| num.parse())
+                .map(|num| {
+                    num.parse()
+                        .map_err(|e| Self::Error::parser_with_error("media num of ports", num, e))
+                })
                 .transpose()?,
             proto: tokenizer.proto.into(),
             fmt: tokenizer.fmt.into(),

--- a/src/types/origin.rs
+++ b/src/types/origin.rs
@@ -26,7 +26,9 @@ impl<'a> TryFrom<Tokenizer<'a>> for Origin {
             sess_version: tokenizer.sess_version.into(),
             nettype: tokenizer.nettype.into(),
             addrtype: tokenizer.addrtype.into(),
-            unicast_address: tokenizer.unicast_address.parse()?,
+            unicast_address: tokenizer.unicast_address.parse().map_err(|e| {
+                Self::Error::parser_with_error("origin ip address", tokenizer.unicast_address, e)
+            })?,
         })
     }
 }

--- a/src/types/time/active.rs
+++ b/src/types/time/active.rs
@@ -14,8 +14,14 @@ impl<'a> TryFrom<Tokenizer<'a>> for Active {
 
     fn try_from(tokenizer: Tokenizer<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
-            start: tokenizer.start.parse()?,
-            stop: tokenizer.stop.parse()?,
+            start: tokenizer
+                .start
+                .parse()
+                .map_err(|e| Self::Error::parser_with_error("time start", tokenizer.start, e))?,
+            stop: tokenizer
+                .stop
+                .parse()
+                .map_err(|e| Self::Error::parser_with_error("time stop", tokenizer.stop, e))?,
         })
     }
 }

--- a/src/types/time/repeat.rs
+++ b/src/types/time/repeat.rs
@@ -17,8 +17,12 @@ impl<'a> TryFrom<Tokenizer<'a>> for Repeat {
 
     fn try_from(tokenizer: Tokenizer<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
-            interval: tokenizer.interval.try_into()?,
-            duration: tokenizer.duration.try_into()?,
+            interval: tokenizer.interval.try_into().map_err(|e| {
+                Self::Error::parser_with_error("repeat interval", tokenizer.interval, e)
+            })?,
+            duration: tokenizer.duration.try_into().map_err(|e| {
+                Self::Error::parser_with_error("repeat duration", tokenizer.duration, e)
+            })?,
             offsets: tokenizer
                 .offsets
                 .into_iter()

--- a/src/types/time/typed_time.rs
+++ b/src/types/time/typed_time.rs
@@ -34,11 +34,31 @@ impl<'a> TryFrom<&'a str> for TypedTime {
 
     fn try_from(part: &'a str) -> Result<Self, Self::Error> {
         let typed_time = match part.chars().last() {
-            Some('s') => Self::Seconds(Duration::seconds(part[0..part.len() - 1].parse::<i64>()?)),
-            Some('m') => Self::Minutes(Duration::minutes(part[0..part.len() - 1].parse::<i64>()?)),
-            Some('h') => Self::Hours(Duration::hours(part[0..part.len() - 1].parse::<i64>()?)),
-            Some('d') => Self::Days(Duration::days(part[0..part.len() - 1].parse::<i64>()?)),
-            _ => Self::None(Duration::seconds(part.parse::<i64>()?)),
+            Some('s') => Self::Seconds(Duration::seconds(
+                part[0..part.len() - 1]
+                    .parse::<i64>()
+                    .map_err(|e| Self::Error::parser_with_error("typed time", part, e))?,
+            )),
+            Some('m') => Self::Minutes(Duration::minutes(
+                part[0..part.len() - 1]
+                    .parse::<i64>()
+                    .map_err(|e| Self::Error::parser_with_error("typed time", part, e))?,
+            )),
+            Some('h') => Self::Hours(Duration::hours(
+                part[0..part.len() - 1]
+                    .parse::<i64>()
+                    .map_err(|e| Self::Error::parser_with_error("typed time", part, e))?,
+            )),
+            Some('d') => Self::Days(Duration::days(
+                part[0..part.len() - 1]
+                    .parse::<i64>()
+                    .map_err(|e| Self::Error::parser_with_error("typed time", part, e))?,
+            )),
+            _ => {
+                Self::None(Duration::seconds(part.parse::<i64>().map_err(|e| {
+                    Self::Error::parser_with_error("typed time", part, e)
+                })?))
+            }
         };
 
         Ok(typed_time)

--- a/src/types/time/zone/zone_part.rs
+++ b/src/types/time/zone/zone_part.rs
@@ -14,8 +14,13 @@ impl<'a> TryFrom<Tokenizer<'a>> for ZonePart {
 
     fn try_from(tokenizer: Tokenizer<'a>) -> Result<Self, Self::Error> {
         Ok(Self {
-            adjustment_time: tokenizer.adjustment.parse()?,
-            offset: tokenizer.offset.try_into()?,
+            adjustment_time: tokenizer.adjustment.parse().map_err(|e| {
+                Self::Error::parser_with_error("zone adjustment time", tokenizer.adjustment, e)
+            })?,
+            offset: tokenizer
+                .offset
+                .try_into()
+                .map_err(|e| Self::Error::parser_with_error("zone offset", tokenizer.offset, e))?,
         })
     }
 }


### PR DESCRIPTION
Having meaningful errors is paramount when doing parsers. This commit
adds basic errors for better debugging. Specifically, whenever a
tokenizer or parser fails, the error will display the element that
the parser or tokenizer thought it was parsing, the actual input that
was parsed for that element and the underlying error that appeared
during parsing/tokenizing.
